### PR TITLE
FixPrivacyGroupId_HashFunction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ function EEAClient(web3, chainId) {
         const buffer = Buffer.from(publicKey, "base64");
         let result = 1;
         buffer.forEach(value => {
-          result = (31 * result + value) % 0x7fffffff;
+          result = (31 * result + (value << 24 >> 24)) & 0xffffffff ;
         });
         return { b64: publicKey, buf: buffer, hash: result };
       })


### PR DESCRIPTION
Fixed the Hashcode function for generating the PrivacyGroupId from the Orion Public Keys.

Tested eventEmitter.js & multinode/*.js with the following key sets:
- Quickstart keys
- Madeline's test keys
- Eric's net-1.1.0-genkey test keys 
- Eric's net-1.1.0-genkey2 test keys 