### PR TITLE
changing arguments in retryOperation invocation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ function EEAClient(web3, chainId) {
       return web3.eth.getTransactionReceipt(txHash);
     };
 
-    return retryOperation(operation, delay, retries);
+    return retryOperation(operation, retries);
   };
 
   /**


### PR DESCRIPTION
When calling "retryOperation" in "getMakerTransaction", there were three arguments. Since the function just accepts two, the "delay" argument should be deleted because it was in place of "retries" argument.