### PR TITLE
[PAN-2764] eeajs example fails when trying to log a connection error, hiding the actual issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,11 @@ function EEAClient(web3, chainId) {
           return result.data.result;
         })
         .catch(error => {
-          throw JSON.stringify(error.response.data);
+          if (error.response) {
+            throw JSON.stringify(error.response.data);
+          } else {
+            throw error;
+          }
         });
     },
     /**


### PR DESCRIPTION
Handle errors that do not have a response from the server
- e.g ENOTFOUND